### PR TITLE
Add a before_recurring hook

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -433,12 +433,14 @@ module Resque
           klass
         )
 
-        if am_master && !should_enqueue
-          log! "skipping queueing of #{config['class']} (#{name})"
-        elsif am_master && should_enqueue
-          log! "queueing #{config['class']} (#{name})"
-          enqueue(config)
-          Resque.last_enqueued_at(name, Time.now.to_s)
+        if am_master
+          if !should_enqueue
+            log! "skipping queueing of #{config['class']} (#{name})"
+          else
+            log! "queueing #{config['class']} (#{name})"
+            enqueue(config)
+            Resque.last_enqueued_at(name, Time.now.to_s)
+          end
         end
       end
 

--- a/lib/resque/scheduler/plugin.rb
+++ b/lib/resque/scheduler/plugin.rb
@@ -26,6 +26,10 @@ module Resque
       def self.run_after_schedule_hooks(klass, *args)
         run_hooks(klass, 'after_schedule', *args)
       end
+
+      def self.run_before_recurring_hooks(klass)
+        run_hooks(klass, 'before_recurring', [])
+      end
     end
   end
 end

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -117,6 +117,33 @@ context 'Resque::Scheduler' do
     assert Resque::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
   end
 
+  test 'enqueue_recurring should not enqueue if not should_enqueue' do
+    class CustomJob
+      def self.before_recurring(*args)
+        return false
+      end
+    end
+    Resque.expects(:last_enqueued_at).never
+    Resque::Scheduler.send(:enqueue_recurring, 'Job', {'class' => 'CustomJob'})
+  end
+
+  test 'enqueue_recurring should enqueue if should_enqueue' do
+    class CustomJob
+      def self.before_recurring(*args)
+        return true
+      end
+    end
+    Resque.expects(:last_enqueued_at)
+    Resque::Scheduler.send(:enqueue_recurring, 'Job', {'class' => 'CustomJob'})
+  end
+
+  test 'enqueue_recurring should enqueue if before_recurring not used' do
+    class CustomJob
+    end
+    Resque.expects(:last_enqueued_at)
+    Resque::Scheduler.send(:enqueue_recurring, 'Job', {'class' => 'CustomJob'})
+  end
+
   test 'load_schedule_job with every with options' do
     Resque::Scheduler.load_schedule_job(
       'some_ivar_job',


### PR DESCRIPTION
ResqueScheduler lacks a hook that fires before a job that comes from its schedule YAML. We need one so that we can stop ondeck from enqueueing jobs.